### PR TITLE
Added subnetwork model

### DIFF
--- a/models/subnet.json
+++ b/models/subnet.json
@@ -1,0 +1,104 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Subnet",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-((0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*)){0,1}(\\+([0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*)){0,1}$",
+      "description": "The version number of this schema."
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of this subnetwork group."
+    },
+    "subnets": {
+      "type": "array",
+      "description": "The actual subnets in this subnetwork group.",
+      "items": {
+        "$ref": "#/definitions/subnet"
+      }
+    },
+    "network": {
+      "$ref": "#/definitions/network",
+      "description": "Selector for the network this subnet should be in."
+    },
+    "region": {
+      "type": "string",
+      "description": "The region of this network.  Not set if this network is more of a top level container/namespace than a deployed network."
+    },
+    "size": {
+      "type": "integer",
+      "description": "The size of this subnet"
+    }
+  },
+  "required": [ "version", "name" ],
+  "dependencies": {
+    "availability_zone": [ "region" ]
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "network": {
+      "title": "Network",
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-((0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*)){0,1}(\\+([0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*)){0,1}$",
+          "description": "The version number of this schema."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of this network."
+        },
+        "id": {
+          "type": "string",
+          "description": "The id of this network."
+        },
+        "parent_id": {
+          "type": "string",
+          "description": "The id of the parent network.  Not set if this is a subnetwork rather than a top level private network."
+        },
+        "region": {
+          "type": "string",
+          "description": "The region of this network.  Not set if this network is more of a top level container/namespace than a deployed network."
+        },
+        "availability_zone": {
+          "type": "string",
+          "description": "The availability zone of this network.  Required in some cloud providers.  Requires region to be set."
+        },
+        "cidr_block": {
+          "type": "string",
+          "description": "The cidr_block of this network.  Not set if this network is more of a top level container/namespace than a deployed network."
+        }
+      }
+    },
+    "subnet": {
+      "title": "Subnet",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of this network."
+        },
+        "id": {
+          "type": "string",
+          "description": "The id of this network."
+        },
+        "region": {
+          "type": "string",
+          "description": "The region of this network.  Not set if this network is more of a top level container/namespace than a deployed network."
+        },
+        "availability_zone": {
+          "type": "string",
+          "description": "The availability zone of this network.  Required in some cloud providers.  Requires region to be set."
+        },
+        "cidr_block": {
+          "type": "string",
+          "description": "The cidr_block of this network.  Not set if this network is more of a top level container/namespace than a deployed network."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This also includes an example of a selector that's modeled after another
resource type.  Extensions to the JSON schema library are needed to
support local file paths, which will remove duplication.